### PR TITLE
S3 이미지 업로드 기능 구현 및 하이브리드 보안 설정 적용

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -29,6 +29,9 @@ jobs:
       # 4. 빌드 (테스트 제외)
       - name: Build with Gradle
         run: ./gradlew clean bootJar -x test
+        env:
+          SPRING_CLOUD_AWS_CREDENTIALS_ACCESS_KEY: ${{ secrets.AWS_ACCESS_KEY }}
+          SPRING_CLOUD_AWS_CREDENTIALS_SECRET_KEY: ${{ secrets.AWS_SECRET_KEY }}
 
       # 5. 기존 파일 지우기 (SCP 전송 전에 청소)
       - name: Clean up old jars

--- a/.gitignore
+++ b/.gitignore
@@ -41,3 +41,6 @@ out/
 
 ### DB Data ###
 db_data/
+
+### Secret Config ###
+src/main/resources/application-secret.yml

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -54,6 +54,9 @@ dependencies {
 
     // Spring Boot Actuator
     implementation("org.springframework.boot:spring-boot-starter-actuator")
+
+    // AWS S3
+    implementation("io.awspring.cloud:spring-cloud-aws-starter-s3:3.0.1")
 }
 
 kotlin {

--- a/src/main/kotlin/com/team10/instagram/global/error/ErrorCode.kt
+++ b/src/main/kotlin/com/team10/instagram/global/error/ErrorCode.kt
@@ -24,4 +24,7 @@ enum class ErrorCode(
     INVALID_REFRESH_TOKEN(HttpStatus.UNAUTHORIZED, "401", "인증 정보가 유효하지 않습니다."),
     REFRESH_TOKEN_EXPIRED(HttpStatus.UNAUTHORIZED, "401", "인증 정보가 만료되었습니다."),
     REFRESH_TOKEN_REUSE_DETECTED(HttpStatus.UNAUTHORIZED, "401", "재발급 토큰이 재사용되었습니다."),
+
+    // 팔로우 관련 에러
+    SELF_FOLLOW_NOT_ALLOWED(HttpStatus.BAD_REQUEST, "FOLLOW_400_1", "자기 자신은 팔로우할 수 없습니다."),
 }

--- a/src/main/kotlin/com/team10/instagram/global/s3/ImageController.kt
+++ b/src/main/kotlin/com/team10/instagram/global/s3/ImageController.kt
@@ -1,0 +1,27 @@
+package com.team10.instagram.global.s3
+
+import io.swagger.v3.oas.annotations.Operation
+import org.springframework.http.MediaType
+import org.springframework.http.ResponseEntity
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RequestPart
+import org.springframework.web.bind.annotation.RestController
+import org.springframework.web.multipart.MultipartFile
+
+@RestController
+@RequestMapping("/api/images")
+class ImageController(
+    private val imageService: ImageService,
+) {
+    // POST /api/images/upload
+    // form-data의 key 이름은 "image"
+    @Operation(summary = "이미지 업로드", description = "이미지 파일을 업로드하고, S3 URL을 반환받습니다.")
+    @PostMapping("/upload", consumes = [MediaType.MULTIPART_FORM_DATA_VALUE])
+    fun uploadImage(
+        @RequestPart("image") image: MultipartFile,
+    ): ResponseEntity<String> {
+        val imageUrl = imageService.upload(image)
+        return ResponseEntity.ok(imageUrl)
+    }
+}

--- a/src/main/kotlin/com/team10/instagram/global/s3/ImageService.kt
+++ b/src/main/kotlin/com/team10/instagram/global/s3/ImageService.kt
@@ -1,0 +1,37 @@
+package com.team10.instagram.global.s3
+
+import io.awspring.cloud.s3.ObjectMetadata
+import io.awspring.cloud.s3.S3Template
+import org.springframework.beans.factory.annotation.Value
+import org.springframework.stereotype.Service
+import org.springframework.web.multipart.MultipartFile
+import java.util.UUID
+
+@Service
+class ImageService(
+    private val s3Template: S3Template,
+    @Value("\${spring.cloud.aws.s3.bucket}")
+    private val bucket: String,
+) {
+    fun upload(file: MultipartFile): String {
+        // 1. 파일 이름 중복 방지 (UUID 사용)
+        // 예: originalFilename = "my_cat.jpg"
+        //     savedFileName = "550e8400-e29b-41d4..._my_cat.jpg"
+        val originalFileName = file.originalFilename ?: "image.jpg"
+        val uuid = UUID.randomUUID().toString()
+        val savedFileName = "${uuid}_$originalFileName"
+
+        // 2. S3에 파일 업로드
+        // upload(버킷이름, 저장할이름, 파일의_InputStream, 메타데이터)
+        val resource =
+            s3Template.upload(
+                bucket,
+                savedFileName,
+                file.inputStream,
+                ObjectMetadata.builder().contentType(file.contentType).build(),
+            )
+
+        // 3. 업로드된 파일의 URL 반환
+        return resource.url.toString()
+    }
+}

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -16,6 +16,16 @@ spring:
       max-file-size: 10MB
       max-request-size: 10MB
 
+  config:
+    import: optional:classpath:application-secret.yml
+
+  cloud:
+    aws:
+      region:
+        static: ap-northeast-2
+      s3:
+        bucket: wafflestudio-team10-instagram-clone
+
 ### TODO : OAuth
 #  security:
 #    oauth2:


### PR DESCRIPTION
- ImageController, ImageService 추가 (POST /api/images/upload)

- 로컬/CI/Prod 환경별 자격 증명 처리 방식 분리
  (로컬: application-secret.yml, CI: Github Secrets, Prod: IAM Role)

- .gitignore에 시크릿 파일 등록

- deploy.yml 빌드 단계에 환경변수 주입 추가