### PR TITLE
[feat] jwt filter 작동 방식 변경

### DIFF
--- a/src/main/kotlin/com/team10/instagram/domain/auth/jwt/JwtAuthenticationFilter.kt
+++ b/src/main/kotlin/com/team10/instagram/domain/auth/jwt/JwtAuthenticationFilter.kt
@@ -1,9 +1,9 @@
 package com.team10.instagram.domain.auth.jwt
 
 import com.team10.instagram.domain.auth.service.JwtTokenBlacklistService
+import com.team10.instagram.domain.user.Role
 import com.team10.instagram.domain.user.model.User
 import com.team10.instagram.domain.user.repository.UserRepository
-import com.team10.instagram.domain.user.Role
 import jakarta.servlet.FilterChain
 import jakarta.servlet.http.HttpServletRequest
 import jakarta.servlet.http.HttpServletResponse
@@ -21,7 +21,6 @@ class JwtAuthenticationFilter(
     private val jwtTokenBlacklistService: JwtTokenBlacklistService,
     private val userRepository: UserRepository,
 ) : OncePerRequestFilter() {
-
     @Value("\${jwt.test-token}")
     private lateinit var testToken: String
 
@@ -35,8 +34,7 @@ class JwtAuthenticationFilter(
         if (token != null) {
             if (token == testToken) {
                 handleTestToken(request)
-            }
-            else if (jwtTokenProvider.validateToken(token!!, jwtTokenBlacklistService)) {
+            } else if (jwtTokenProvider.validateToken(token!!, jwtTokenBlacklistService)) {
                 // 실제 토큰 처리
                 val userId = jwtTokenProvider.getUserId(token!!)
                 request.setAttribute("userId", userId)
@@ -44,11 +42,12 @@ class JwtAuthenticationFilter(
                 val user = userRepository.findByUserId(userId)
 
                 if (user != null) {
-                    val auth = UsernamePasswordAuthenticationToken(
-                        user,
-                        null,
-                        listOf(SimpleGrantedAuthority("ROLE_${user.role.name}"))
-                    )
+                    val auth =
+                        UsernamePasswordAuthenticationToken(
+                            user,
+                            null,
+                            listOf(SimpleGrantedAuthority("ROLE_${user.role.name}")),
+                        )
                     SecurityContextHolder.getContext().authentication = auth
                 }
             }
@@ -60,21 +59,23 @@ class JwtAuthenticationFilter(
     }
 
     private fun handleTestToken(request: HttpServletRequest) {
-        val user = userRepository.findByEmail("test@swagger.com")
-            ?: userRepository.save(
-                User(
-                    email = "test@swagger.com",
-                    password = BCryptPasswordEncoder().encode("password123"),
-                    nickname = "swagger_tester",
-                    role = Role.USER,
-                ),
-            )
+        val user =
+            userRepository.findByEmail("test@swagger.com")
+                ?: userRepository.save(
+                    User(
+                        email = "test@swagger.com",
+                        password = BCryptPasswordEncoder().encode("password123"),
+                        nickname = "swagger_tester",
+                        role = Role.USER,
+                    ),
+                )
         request.setAttribute("userId", user.userId)
-        val auth = UsernamePasswordAuthenticationToken(
-            user,
-            null,
-            listOf(SimpleGrantedAuthority("ROLE_USER")),
-        )
+        val auth =
+            UsernamePasswordAuthenticationToken(
+                user,
+                null,
+                listOf(SimpleGrantedAuthority("ROLE_USER")),
+            )
         SecurityContextHolder.getContext().authentication = auth
     }
 

--- a/src/main/kotlin/com/team10/instagram/domain/auth/jwt/JwtAuthenticationFilter.kt
+++ b/src/main/kotlin/com/team10/instagram/domain/auth/jwt/JwtAuthenticationFilter.kt
@@ -1,9 +1,9 @@
 package com.team10.instagram.domain.auth.jwt
 
 import com.team10.instagram.domain.auth.service.JwtTokenBlacklistService
-import com.team10.instagram.domain.user.Role
 import com.team10.instagram.domain.user.model.User
 import com.team10.instagram.domain.user.repository.UserRepository
+import com.team10.instagram.domain.user.Role
 import jakarta.servlet.FilterChain
 import jakarta.servlet.http.HttpServletRequest
 import jakarta.servlet.http.HttpServletResponse
@@ -13,7 +13,6 @@ import org.springframework.security.core.authority.SimpleGrantedAuthority
 import org.springframework.security.core.context.SecurityContextHolder
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder
 import org.springframework.stereotype.Component
-import org.springframework.util.AntPathMatcher
 import org.springframework.web.filter.OncePerRequestFilter
 
 @Component
@@ -22,7 +21,6 @@ class JwtAuthenticationFilter(
     private val jwtTokenBlacklistService: JwtTokenBlacklistService,
     private val userRepository: UserRepository,
 ) : OncePerRequestFilter() {
-    private val pathMatcher = AntPathMatcher()
 
     @Value("\${jwt.test-token}")
     private lateinit var testToken: String
@@ -32,53 +30,52 @@ class JwtAuthenticationFilter(
         response: HttpServletResponse,
         filterChain: FilterChain,
     ) {
-        if (isPublicPath(request.requestURI)) {
-            filterChain.doFilter(request, response)
-            return
-        }
-
         val token = resolveToken(request)
 
-        if (token == testToken) {
-            val user =
-                userRepository.findByEmail("test@swagger.com")
-                    ?: userRepository.save(
-                        User(
-                            email = "test@swagger.com",
-                            password = BCryptPasswordEncoder().encode("password123"),
-                            nickname = "swagger_tester",
-                            role = Role.USER,
-                        ),
-                    )
-            request.setAttribute("userId", user.userId)
-            val auth =
-                UsernamePasswordAuthenticationToken(
-                    user,
-                    null,
-                    listOf(SimpleGrantedAuthority("ROLE_USER")),
-                )
-            SecurityContextHolder.getContext().authentication = auth
-            filterChain.doFilter(request, response)
-            return
-        } else if (token != null && jwtTokenProvider.validateToken(token, jwtTokenBlacklistService)) {
-            val userId = jwtTokenProvider.getUserId(token)
-            request.setAttribute("userId", userId)
-            val user = userRepository.findByUserId(userId)
-            if (user != null) {
-                val auth =
-                    UsernamePasswordAuthenticationToken(
+        if (token != null) {
+            if (token == testToken) {
+                handleTestToken(request)
+            }
+            else if (jwtTokenProvider.validateToken(token!!, jwtTokenBlacklistService)) {
+                // 실제 토큰 처리
+                val userId = jwtTokenProvider.getUserId(token!!)
+                request.setAttribute("userId", userId)
+
+                val user = userRepository.findByUserId(userId)
+
+                if (user != null) {
+                    val auth = UsernamePasswordAuthenticationToken(
                         user,
                         null,
-                        listOf(SimpleGrantedAuthority(user.role.name)),
+                        listOf(SimpleGrantedAuthority("ROLE_${user.role.name}"))
                     )
-                SecurityContextHolder.getContext().authentication = auth
+                    SecurityContextHolder.getContext().authentication = auth
+                }
             }
-        } else {
-            response.sendError(HttpServletResponse.SC_UNAUTHORIZED, "Invalid or missing token")
-            return
         }
 
+        // 토큰이 없거나 유효하지 않아도 통과시킴
+        // CORS 요청, Public API, 에러 페이지 등은 SecurityConfig가 알아서 처리
         filterChain.doFilter(request, response)
+    }
+
+    private fun handleTestToken(request: HttpServletRequest) {
+        val user = userRepository.findByEmail("test@swagger.com")
+            ?: userRepository.save(
+                User(
+                    email = "test@swagger.com",
+                    password = BCryptPasswordEncoder().encode("password123"),
+                    nickname = "swagger_tester",
+                    role = Role.USER,
+                ),
+            )
+        request.setAttribute("userId", user.userId)
+        val auth = UsernamePasswordAuthenticationToken(
+            user,
+            null,
+            listOf(SimpleGrantedAuthority("ROLE_USER")),
+        )
+        SecurityContextHolder.getContext().authentication = auth
     }
 
     private fun resolveToken(request: HttpServletRequest): String? {
@@ -88,10 +85,4 @@ class JwtAuthenticationFilter(
         }
         return null
     }
-
-    private fun isPublicPath(path: String): Boolean =
-        pathMatcher.match("/api/v1/auth/**", path) ||
-            pathMatcher.match("/swagger-ui/**", path) ||
-            pathMatcher.match("/v3/api-docs/**", path) ||
-            pathMatcher.match("/actuator/health", path)
 }

--- a/src/main/kotlin/com/team10/instagram/global/config/SecurityConfig.kt
+++ b/src/main/kotlin/com/team10/instagram/global/config/SecurityConfig.kt
@@ -44,6 +44,8 @@ class SecurityConfig(
                 it.requestMatchers("/").permitAll()
                 // Auth 경로
                 it.requestMatchers("/api/v1/auth/**").permitAll()
+                // 에러 발생 시 Spring이 내부적으로 호출하는 경로
+                it.requestMatchers("/error").permitAll()
                 // 나머지 요청은 인증 필요
                 it.anyRequest().authenticated()
             }.addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter::class.java)
@@ -58,7 +60,6 @@ class SecurityConfig(
         configuration.allowedOrigins =
             listOf(
                 "https://www.wfinstaclone.shop", // domain
-                "https://www.api.wfinstaclone.shop", // domain
                 "https://d1ki8kre4wetjx.cloudfront.net", // Front
                 "http://localhost:3000", // 로컬 (React/Next.js)
                 "http://localhost:5173", // 로컬 (Vite)


### PR DESCRIPTION
1. isPublicPath 함수를 삭제했고, 이제 토큰이 없거나 검증에 실패해도 에러를 내지 않고 filterChain.doFilter를 통해 그냥 통과시킵니다.
(CORS 요청과 Security 처리 정상 작동을 위해)

2. 기존 isPublicPath의 기능을 SecurityConfig에서 대신합니다. (이미 있던 기능이라, 기능 중복이었습니다)

3. /error 경로를 permitAll에 추가하여, 인증 실패 시 403이 아닌 401 에러가 명확하게 전달되도록 수정하였습니다.